### PR TITLE
inserted coder in parms (set to 0 by default)

### DIFF
--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -1,10 +1,11 @@
-function odefun = dnsimulator(spec,coder,varargin)
+function odefun = dnsimulator(spec,varargin)
 parms = mmil_args2parms( varargin, ...
                          {...
                             'timelimits',[0 200],[],...
                             'logfid',1,[],...
                             'dt',.02,[],...
                             'SOLVER','euler',[],...
+                            'coder',0,[],...
                          }, false);
 
 tspan = parms.timelimits;
@@ -33,7 +34,7 @@ odefun_file = [subdir,'_' datestr(now,'yyyymmdd_HHMMSS')];
 odefun = [subdir,'/',odefun_file];
 fid=fopen([odefun '.m'],'wt');
 
-if ~exist('codegen') || coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
+if ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
   fprintf(fid,'function [Y,T] = %s\n',odefun_file);
 else
   fprintf(fid,'function [Y,T] = odefun\n'); % this is useful to avoid codegen to be called if the mex file is already created
@@ -42,7 +43,7 @@ end
 fprintf(fid,'tspan=[%g %g]; dt=%g;\n',tspan,dt);
 fprintf(fid,'T=tspan(1):dt:tspan(2); nstep=length(T);\n');
 
-if ischar(fileID) && (~exist('codegen') || coder == 0) % if matlab coder is not available or you don't want to use it because it does not support your code
+if ischar(fileID) && (~exist('codegen') || parms.coder == 0) % if matlab coder is not available or you don't want to use it because it does not support your code
   fprintf(fid,'fileID = %s; nreports = 5; tmp = 1:(nstep-1)/nreports:nstep; enableLog = tmp(2:end);\n',fileID);
 else
     fprintf(fid,'fileID = %d; nreports = 5; tmp = 1:(nstep-1)/nreports:nstep; enableLog = tmp(2:end);\n',fileID);
@@ -57,7 +58,7 @@ for k = 1:size(auxvars,1)
 end
 
 %  % evaluate anonymous functions
-%  if ~exist('codegen') || coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
+%  if ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
 %    for k = 1:size(functions,1)
 %      fprintf(fid,'%s = %s;\n',functions{k,1},functions{k,2});
 %    end
@@ -91,7 +92,7 @@ end
 odes = splitstr(model(9:end-2),';');
 
 % Integrate
-if ~exist('codegen') || coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
+if ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
   fprintf(fid,'tstart = tic;\n');
 end
 switch solver
@@ -106,7 +107,7 @@ switch solver
         fprintf(fid,'  %s(k) = %s(k-1) + dt*F;\n',ulabels{i},ulabels{i});
       end
     end
-    if ~exist('codegen') || coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
+    if ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
       enableLog(fid);
     end
     fprintf(fid,'end\n');
@@ -135,7 +136,7 @@ switch solver
         fprintf(fid,'  %s(k) = %s(k-1) + dt*%s2;\n',ulabels{i},ulabels{i},ulabels{i});
       end
     end
-    if ~exist('codegen') || coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
+    if ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
       enableLog(fid);
     end
     fprintf(fid,'end\n');
@@ -191,7 +192,7 @@ switch solver
         fprintf(fid,'  %s(k) = %s(k-1) + (dt/6)*(%s1+2*(%s2+%s3)+%s4);\n',ulabels{i},ulabels{i},ulabels{i},ulabels{i},ulabels{i},ulabels{i});
       end
     end
-    if ~exist('codegen') || coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
+    if ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
       enableLog(fid);
     end
     fprintf(fid,'end\n');

--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -8,8 +8,6 @@ function [simdata,spec,parms] = runsim(varargin)
 % ----------------------------------------------------------
 % get specification
 
-coder = 1; % 0; % 1; whether or not matlab code generator is enabled
-
 if nargin>0 && isstruct(varargin{1}) % biosim(spec,...)
   spec = varargin{1};
   if nargin>1, varargin = varargin(2:end); end
@@ -63,6 +61,7 @@ parms = mmil_args2parms( varargin, ...
                               'verbose',1,[],...
                               'couple_flag',0,[],...
                               'nofunctions',1,[],...
+                              'coder',0,[],...
                            }, false);
 
 % ----------------------------------------------------------
@@ -102,12 +101,12 @@ end
 try args = mmil_parms2args(parms); catch args = {}; end
 switch parms.SOLVER
   case {'euler','rk2','modifiedeuler','rk4'}
-    file = dnsimulator(spec,coder,args{:});
+    file = dnsimulator(spec,args{:});
     tmp_str = strsplit(file,'/');
     odefun_dir = tmp_str{1};
     file = tmp_str{2};
     cd(odefun_dir);
-    if  ~exist('codegen') || coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
+    if  ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
       [data,t] = feval(file);
       delete([file,'.m']);
     else


### PR DESCRIPTION
Similarly to verbose or any other parameter, one can now set whether to use codegen or not in the runsim function call, by default set to 0.
