### PR TITLE
do not remove m file on errors if mex file exists

### DIFF
--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -155,7 +155,7 @@ switch parms.SOLVER
         fprintf('\t in %s (line %g)\n',err.stack(i).name,err.stack(i).line);
       end
       simdata=[];
-      if exist([file,'.m'],'file') && parms.debug==0
+      if exist([file,'.m'],'file') && if ~exist([file,'.mex'],'file') && parms.debug==0
          delete([file,'.m']);
       end
       if exist('params.mat','file') && parms.debug==0


### PR DESCRIPTION
If for whatever reason one manually stops a simulation that uses codegen, dnsim will remove the associated odefun.m file. This is not something we want as it creates an orphan mex file. A new simulation will create a new pair of m and mex files (just exact copies of the previous but with different names) and previous mex file will stay there and be useless.

This is a simple fix for that.
