### PR TITLE
adjust dt for external functions under R-K

### DIFF
--- a/matlab/functions/buildmodel.m
+++ b/matlab/functions/buildmodel.m
@@ -81,7 +81,7 @@ parms = mmil_args2parms( varargin, ...
 % note: override = {label,field,value,[arg]; ...}
 fileID = parms.logfid;
 
-if parms.coder==1
+if parms.coder==1 && exist('codegen')
   coderprefix = 'pset.p.';
   % (param struct in odefun).(param var below).(param name in buildmodel)
 else
@@ -162,7 +162,7 @@ if issubfield(spec,'simulation.timelimits')
 else
   timelimits = parms.timelimits;
 end
-if parms.coder==1
+if parms.coder==1 && exist('codegen')
   modelparams.dt = dt;
   modelparams.timelimits = timelimits;
 end
@@ -428,7 +428,7 @@ for i=1:N
       n=length(E.parameters)/2; I=pcnt+(1:n);
       keys=E.parameters(1:2:end);
       vals=E.parameters(2:2:end);
-      if parms.coder==0
+      if parms.coder==0 || ~exist('codegen')
         [Pdata{I,1}]=deal(keys{:});
         [Pdata{I,2}]=deal(vals{:});
       else
@@ -473,12 +473,12 @@ for i=1:N
         keys=E.parameters(1:2:2*n);
         vals=E.parameters(2:2:2*n);
       end
-      if parms.coder==0
+      if parms.coder==0 || ~exist('codegen')
         [Pdata{I,1}]=deal(keys{:});
         [Pdata{I,2}]=deal(vals{:});
       else
         for j=1:length(I)
-          %newlabel=[EL{i} '_' keys{j}]; 
+          %newlabel=[EL{i} '_' keys{j}];
           newlabel=[prefix '_' keys{j}];
           Pdata{I(j),1} = keys{j};
           Pdata{I(j),2} = newlabel;
@@ -512,7 +512,7 @@ for i=1:N
       keys=fieldnames(M.params);
       vals=struct2cell(M.params);
       n=length(keys); I=pcnt+(1:n);
-      if parms.coder==0
+      if parms.coder==0 || ~exist('codegen')
         [Pdata{I,1}]=deal(keys{:});
         [Pdata{I,2}]=deal(vals{:});
       else
@@ -601,7 +601,7 @@ for m=1:nmech
   ic=Svars(Smech==m,4);
   % substitute global user params: into (expressions, functions, odes, terms)
   old=Pdata(Pmech==m & Ptype==0,1); new=Pdata(Pmech==m & Ptype==0,2);
-  if parms.coder==1
+  if parms.coder==1 && exist('codegen')
     for k=1:length(new)
       if ischar(new{k}), new{k}=[coderprefix new{k}]; end;
     end
@@ -609,7 +609,7 @@ for m=1:nmech
   [f,e,o,t,ic]=substitute(old,new,f,e,o,t,ic);
   % substitute default mech params | same pop & mech: into (expressions, functions, odes, terms)
   old=Pdata(Pmech==m & Ptype==1,1); new=Pdata(Pmech==m & Ptype==1,2);
-  if parms.coder==1
+  if parms.coder==1 && exist('codegen')
     for k=1:length(new)
       if ischar(new{k}), new{k}=[coderprefix new{k}]; end;
     end
@@ -620,7 +620,7 @@ for m=1:nmech
   n0=NE(k0); % target pop size (postsynaptic)
   if m>0, k1=Minputs{m}(1); else k1=k0; end
   n1=NE(k1); % source pop size (presynaptic)
-  if parms.coder==0
+  if parms.coder==0 || ~exist('codegen')
     old={'Npre','N[1]','Npost','N[0]','Npop','dt'};
     new={n1,n1,n0,n0,n0,dt};
     if ~isempty(timelimits)
@@ -641,7 +641,7 @@ for m=1:nmech
   [f,e,o,t,ic]=substitute(old,new,f,e,o,t,ic);
   % ------------------------------------------------
   % go ahead and substitute values into ICs for coder
-  if parms.coder==1
+  if parms.coder==1 && exist('codegen')
     old2a=Pdata(Pmech==m & Ptype==0,2); % entity params
     old2b=Pdata(Pmech==m & Ptype==1,2); % mechanism params
     old2c={src,dst,dst}';               % reserved params
@@ -724,7 +724,7 @@ for e=1:length(E)
   o=substitute(old,new,o);
   % parameters into odes
   old=Pdata(Ptype==0,1); new=Pdata(Ptype==0,2);
-  if parms.coder==1
+  if parms.coder==1 && exist('codegen')
     for k=1:length(new)
       if ischar(new{k}), new{k}=[coderprefix new{k}]; end;
     end
@@ -732,7 +732,7 @@ for e=1:length(E)
   o=substitute(old,new,o);
   % reserve keywords into odes
   n0=NE(e);
-  if parms.coder==0
+  if parms.coder==0 || ~exist('codegen')
     old={'Npost','N[0]','Npop','dt'};
     new={n0,n0,n0,dt};
   else
@@ -938,7 +938,7 @@ for i=1:nvar
   Pg=Pdata(Ptype==0 & Ppop==Spop(i),:);
   if any(find(cellfun(@(x)isequal(x,[s '_IC']),Pg(:,1))))
     ind2=find(cellfun(@(x)isequal(x,[s '_IC']),Pg(:,1)));
-    if parms.coder==0
+    if parms.coder==0 || ~exist('codegen')
       icval=Pg{ind2(1),2};
     else
       icval=modelparams.(Pg{ind2(1),2});
@@ -951,7 +951,7 @@ for i=1:nvar
       ic = eval(icval);
     end
   end
-  if ischar(ic) %&& parms.coder==0
+  if ischar(ic) %&& (parms.coder==0 || ~exist('codegen'))
     ic=eval(ic);
   elseif numel(ic)==1
     ic=repmat(ic,[NE(Spop(i)) 1]);
@@ -959,7 +959,7 @@ for i=1:nvar
   if size(ic,1)<size(ic,2), ic=ic'; end
 %   if any(find(cellfun(@(x)isequal(x,[s '_IC_noise']),Pg(:,1))))
 %     ind2=find(cellfun(@(x)isequal(x,[s '_IC_noise']),Pg(:,1)));
-%     if parms.coder==0
+%     if parms.coder==0 || ~exist('codegen')
 %       icnoise=Pg{ind2(1),2};
 %       ic=ic+icnoise.*rand(size(ic));
 %     else
@@ -970,7 +970,7 @@ for i=1:nvar
   Svars{i,4}=ic;
   Svars{i,3}=stateindx+(1:length(ic));
   stateindx=stateindx+length(ic);
-  if parms.coder==1
+  if parms.coder==1 && exist('codegen')
     % store ICs for setting in odefun file using params.mat
     fld=sprintf('IC_%s',Svars{i,2});
     modelparams.(fld) = ic;
@@ -1121,7 +1121,7 @@ sys.model.auxvars = auxvars;
 sys.model.ode = model;
 sys.model.IC = IC;
 sys.model.parms = parms;
-if parms.coder==1
+if parms.coder==1 && exist('codegen')
   sys.model.parameters = modelparams;
 end
 

--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -76,6 +76,18 @@ fprintf(fid,'fprintf(''Starting integration (%s, dt=%%g)\\n'',dt);\n',solver);
 
 % evaluate auxiliary variables (ie., adjacency matrices)
 for k = 1:size(auxvars,1)
+  if strncmp(solver,'rk',2)
+    dt_scaling_factor = '0.5';
+    strParts = strsplit(auxvars{k,2},{'pset.p.'});
+    for l = 2:length(strParts)
+      strParts{l} = ['pset.p.',strParts{l}];
+      if regexp(strParts{l}, '^.+_dt[,)]$')
+        prevStr = strParts{l}(1:end-1);
+        newStr = regexprep(strParts{l}(1:end-1), '^.+_dt$', [dt_scaling_factor,'\*',strParts{l}(1:end-1)]);
+        fprintf(fid,'%s = %s; \n',prevStr,newStr);
+      end
+    end
+  end
   fprintf(fid,'%s = %s;\n',auxvars{k,1},auxvars{k,2});
 end
 

--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -83,7 +83,7 @@ for k = 1:size(auxvars,1)
       strParts{l} = ['pset.p.',strParts{l}];
       if regexp(strParts{l}, '^.+_dt[,)]$')
         prevStr = strParts{l}(1:end-1);
-        newStr = regexprep(strParts{l}(1:end-1), '^.+_dt$', [dt_scaling_factor,'\*',strParts{l}(1:end-1)]);
+        newStr = regexprep(strParts{l}(1:end-1), '^.+_dt$', [dt_scaling_factor,'*',strParts{l}(1:end-1)]);
         fprintf(fid,'%s = %s; \n',prevStr,newStr);
       end
     end


### PR DESCRIPTION
This modification is to keep the same precision for external functions, such as the Poisson input, dicated by the integration method. So if RK2 or RK4 is used instead of Euler, then actual dt of the external function is scaled down to 0.5dt.
