### PR TITLE
Getting rid of strsplit by using instead splitstr (dnsim dependency)

### DIFF
--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -78,7 +78,7 @@ fprintf(fid,'fprintf(''Starting integration (%s, dt=%%g)\\n'',dt);\n',solver);
 for k = 1:size(auxvars,1)
   if strncmp(solver,'rk',2)
     dt_scaling_factor = '0.5';
-    strParts = strsplit(auxvars{k,2},{'pset.p.'});
+    strParts = splitstr(auxvars{k,2},{'pset.p.'});
     for l = 2:length(strParts)
       strParts{l} = ['pset.p.',strParts{l}];
       if regexp(strParts{l}, '^.+_dt[,)]$')

--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -107,7 +107,7 @@ try args = mmil_parms2args(parms); catch args = {}; end
 switch parms.SOLVER
   case {'euler','rk2','modifiedeuler','rk4'}
     file = dnsimulator(spec,args{:});
-    tmp_str = strsplit(file,'/');
+    tmp_str = splitstr(file,'/');
     odefun_dir = tmp_str{1};
     file = tmp_str{2};
     cwd=pwd; cd(odefun_dir);


### PR DESCRIPTION
I just replaced strsplit by splitstr (dependency of dnsim). This should fix the issues of Ben not being able to run dnsim locally on Matlab 2012.

I will test whether I can get rid of the dependency as well by using strread instead...
