### PR TITLE
Fix #48: Add job number precision to odefun file

### DIFF
--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -52,7 +52,7 @@ if exist('codegen') && parms.coder==1
 end
 
 % create odefun file that integrates the ODE system
-odefun_file = [subdir,'_' datestr(now,'yyyymmdd_HHMMSS')];
+odefun_file = [subdir,'_' datestr(now,'yyyymmdd_HHMMSSFFF') '_' spec.jobnumber];
 odefun = [subdir,'/',odefun_file];
 fid=fopen([odefun '.m'],'wt');
 
@@ -70,7 +70,7 @@ fprintf(fid,'T=tspan(1):dt:tspan(2); nstep=length(T);\n');
 if ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
   fprintf(fid,'nreports = 5; tmp = 1:(nstep-1)/nreports:nstep; enableLog = tmp(2:end);\n');
 end
-
+fprintf(fid,'fprintf(''\\nThe odefun file used is: %s \\n'');\n',odefun_file);
 fprintf(fid,'fprintf(''\\nSimulation interval: %%g-%%g\\n'',tspan(1),tspan(2));\n');
 fprintf(fid,'fprintf(''Starting integration (%s, dt=%%g)\\n'',dt);\n',solver);
 

--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -114,7 +114,6 @@ switch parms.SOLVER
     try
       if  ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
         [data,t] = feval(file);
-        delete([file,'.m']);
       else
         odefun_mfiles = {};
         dirinfo = dir('.');
@@ -124,7 +123,6 @@ switch parms.SOLVER
           if ~dirinfo(j).isdir && ~strcmp(dirinfo(j).name(1:end-2),file) && strncmp(dirinfo(j).name,file,6) &&  strncmp(dirinfo(j).name(end-1:end),'.m',2)
             [~,res_diff] = system(['diff ',file,'.m ',dirinfo(j).name]);
             if isempty(res_diff)
-              delete([file,'.m']);
               file = dirinfo(j).name(1:end-2);
               display('Using previous mex file');
               filemex = [file,'_mex']
@@ -141,10 +139,8 @@ switch parms.SOLVER
         tic
         [data,t] = feval(filemex);
         if parms.debug==0
-          delete('params.mat');
         end
         if exist('codemex','dir')
-          rmdir('codemex','s');
         end
         toc
       end
@@ -156,10 +152,8 @@ switch parms.SOLVER
       end
       simdata=[];
       if exist([file,'.m'],'file') && ~exist([file,'.mex'],'file') && parms.debug==0
-         delete([file,'.m']);
       end
       if exist('params.mat','file') && parms.debug==0
-        delete('params.mat');
       end
       if exist('codemex','dir')
         rmdir('codemex','s');
@@ -168,7 +162,7 @@ switch parms.SOLVER
       return
     end
     if exist('odefun','dir') && length(dir('odefun'))==2 % empty directory
-      rmdir('odefun');
+      % rmdir('odefun');
     end
   otherwise
     [data,t] = biosimulator(model,ic,functions,auxvars,args{:});

--- a/matlab/functions/simstudy.m
+++ b/matlab/functions/simstudy.m
@@ -212,6 +212,7 @@ if spec.simulation.cluster_flag % run on cluster
       auxcmd2 = auxcmd;
     end
     modelspec=allspecs{k};
+    modelspec.jobnumber = sprintf('job%4.4i',k);
     specfile = sprintf('spec%g.mat',k);
     save(specfile,'modelspec');
     jobs{end+1} = sprintf('job%g.m',k);
@@ -286,6 +287,7 @@ else
   % run on local machine
   for specnum = 1:length(allspecs) % loop over elements of search space
     modelspec = allspecs{specnum};
+    modelspec.jobnumber = sprintf('job%4.4i',1);
     fprintf(logfid,'processing simulation...');
     try
       biosimdriver(modelspec,'rootoutdir',rootoutdir{specnum},'prefix',prefix{specnum},'verbose',1,...


### PR DESCRIPTION
```
modified:   matlab/functions/dnsimulator.m
modified:   matlab/functions/runsim.m
modified:   matlab/functions/simstudy.m
```

Using the cluster with the dev branch SHOULD be simulation-safe, now, in that simulations should not surreptitiously overwrite each other anymore. The problem appears to have been that the `odefun` files were only created with a precision down to seconds, but in a shared directory. Therefore, sometimes the cluster would make 2 `odefun` files for different simulations within a second of each other, but only one would be saved; this same one would then be used as the core simulation file for more than one simulation, EVEN THOUGH there is supposed to be a 1-to-1 match between `odefun` files and simulations. By adding time down to milliseconds and the job number itself (passed through the gigantic `spec` data structure that will one day be cleaned), each `odefun` file in a batch should now be unique.

Also, all `odefun` files are now saved by default, as I didn't see a flag to enable that, and it will be helpful in fixing other odefun-related bugs.
