### PR TITLE
Changes that improve usability: 1) params.mat is used whether or not …

### DIFF
--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -80,7 +80,7 @@ for k = 1:length(ulabels)
   fprintf(fid,'coder.varsize(''%s.%s'');\n',coderprefix,['IC_' ulabels{k}]);
 end
 % load params.mat at start of odefun file
-fprintf(fid,'pset=load(''params'',''-mat'');\n'); % variable name 'pset' must match coderprefix
+fprintf(fid,'pset=load(''params.mat'');\n'); % variable name 'pset' must match coderprefix
 fprintf(fid,'tspan=%s.timelimits;\ndt=%s.dt;\n',coderprefix,coderprefix);
 fprintf(fid,'T=tspan(1):dt:tspan(2);\nnstep=length(T);\n');
 

--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -48,11 +48,13 @@ if parms.cluster_flag % write params to job-specific subdir
 end
 odefun_subdir = fullfile(pwd,odefun_dir,subdir);
 if exist(odefun_subdir,'dir')
-  cont = 0;
+  cont = 1;
+  subdir = [subdir,'_',num2str(cont)];
+  odefun_subdir = fullfile(pwd,odefun_dir,subdir);
   while exist(odefun_subdir,'dir')
     cont = cont+1;
     tmpstr = strread(subdir,'%s','delimiter','_');
-    subdir = [tmpstr{1},'_',num2str(cont)];
+    subdir = [tmpstr{1:end-1},'_',num2str(cont)];
     odefun_subdir = fullfile(pwd,odefun_dir,subdir);
   end
 end

--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -42,10 +42,11 @@ subdir = parms.identifier;
 
 % write params.mat
 p = spec.model.parameters; % variable name 'p' must match coderprefix
-if parms.cluster_flag % write params to job-specific subdir
-  stck = dbstack;
-  subdir = fullfile(subdir,stck(end).name); % create subdir for this job
-end
+% this is not needed anymore for new odefun identifiers
+% if parms.cluster_flag % write params to job-specific subdir
+%   stck = dbstack;
+%   subdir = fullfile(subdir,stck(end).name); % create subdir for this job
+% end
 odefun_subdir = fullfile(pwd,odefun_dir,subdir);
 if exist(odefun_subdir,'dir')
   cont = 1;

--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -80,7 +80,7 @@ for k = 1:length(ulabels)
   fprintf(fid,'coder.varsize(''%s.%s'');\n',coderprefix,['IC_' ulabels{k}]);
 end
 % load params.mat at start of odefun file
-fprintf(fid,'pset=load(''params.mat'');\n'); % variable name 'pset' must match coderprefix
+fprintf(fid,'pset=load(''params'',''-mat'');\n'); % variable name 'pset' must match coderprefix
 fprintf(fid,'tspan=%s.timelimits;\ndt=%s.dt;\n',coderprefix,coderprefix);
 fprintf(fid,'T=tspan(1):dt:tspan(2);\nnstep=length(T);\n');
 

--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -54,7 +54,11 @@ if exist(odefun_subdir,'dir')
   while exist(odefun_subdir,'dir')
     cont = cont+1;
     tmpstr = strread(subdir,'%s','delimiter','_');
-    subdir = [tmpstr{1:end-1},'_',num2str(cont)];
+    tmpstr2 = tmpstr{1};
+    for i = 2:length(tmpstr)-1
+      tmpstr2 = [tmpstr2,'_',tmpstr{i}];
+    end
+    subdir = [tmpstr2,'_',num2str(cont)];
     odefun_subdir = fullfile(pwd,odefun_dir,subdir);
   end
 end

--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -260,5 +260,5 @@ while ~exist([odefun_filepath '.m'],'file')
   pause(.01);
 end
 
-fprintf('running simulation...\n');
+fprintf('Starting the simulation...\n');
 % eval(sprintf('[data,t]=%s;',odefun_file));

--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -68,10 +68,11 @@ save(fullfile(odefun_subdir,'params.mat'),'p');
 
 % create odefun file that integrates the ODE system
 odefun_file = [odefun_dir,'_' datestr(now,'yyyymmdd_HHMMSS_FFF')];
-% this doesn't work for me and I don't think it is actually needed
-%  if parms.cluster_flag % not assuming the cluster is always used
-%    odefun_file = [odefun_file '_' spec.jobnumber]
-%  end
+if parms.cluster_flag % not assuming the cluster is always used
+  odefun_file = [odefun_file '_jid' getenv('JOB_ID')];
+  % couldn't get this to work
+  % odefun_file = [odefun_file '_' spec.jobnumber];
+end
 odefun_filepath = [odefun_subdir,'/',odefun_file];
 fid=fopen([odefun_filepath '.m'],'wt');
 

--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -1,4 +1,4 @@
-function odefun = dnsimulator(spec,varargin)
+function odefun_filepath = dnsimulator(spec,varargin)
 parms = mmil_args2parms( varargin, ...
                          {...
                             'timelimits',[0 200],[],...
@@ -8,6 +8,7 @@ parms = mmil_args2parms( varargin, ...
                             'cluster_flag',0,[],...
                             'coder',0,[],...
                             'debug',0,[],...
+                            'identifier','default',[],...
                          }, false);
 coderprefix = 'pset.p';
 % (param struct in odefun).(param var below).(param name in buildmodel)
@@ -32,57 +33,63 @@ T = tspan(1):dt:tspan(2);
 nstep = length(T);
 
 % create subdirectory for temporary integrator scripts
-subdir = 'odefun';
-if ~exist(fullfile(pwd,subdir),'dir')
-  mkdir(subdir);
+odefun_dir = 'odefun';
+if ~exist(fullfile(pwd,odefun_dir),'dir')
+  mkdir(odefun_dir);
 end
 
-% write params.mat if using coder
-if exist('codegen') && parms.coder==1
-  p=spec.model.parameters; % variable name 'p' must match coderprefix
-  if parms.cluster_flag % write params to job-specific subdir
-    stck=dbstack;
-    subdir2=fullfile(subdir,stck(end).name); % create subdir for this job
-    if ~exist(subdir2,'dir')
-      mkdir(subdir2);
-    end
-    save(fullfile(subdir2,'params.mat'),'p');
-  else
-    save(fullfile(subdir,'params.mat'),'p');
+subdir = parms.identifier;
+
+% write params.mat
+p = spec.model.parameters; % variable name 'p' must match coderprefix
+if parms.cluster_flag % write params to job-specific subdir
+  stck = dbstack;
+  subdir = fullfile(subdir,stck(end).name); % create subdir for this job
+end
+odefun_subdir = fullfile(pwd,odefun_dir,subdir);
+if exist(odefun_subdir,'dir')
+  cont = 0;
+  while exist(odefun_subdir,'dir')
+    cont = cont+1;
+    tmpstr = strread(subdir,'%s','delimiter','_');
+    subdir = [tmpstr{1},'_',num2str(cont)];
+    odefun_subdir = fullfile(pwd,odefun_dir,subdir);
   end
 end
+mkdir(odefun_subdir);
+save(fullfile(odefun_subdir,'params.mat'),'p');
 
 % create odefun file that integrates the ODE system
-odefun_file = [subdir,'_' datestr(now,'yyyymmdd_HHMMSS_FFF')];
+odefun_file = [odefun_dir,'_' datestr(now,'yyyymmdd_HHMMSS_FFF')];
 if parms.cluster_flag % not assuming the cluster is always used
   odefun_file = [odefun_file '_' spec.jobnumber]
 end
-odefun = [subdir,'/',odefun_file];
-fid=fopen([odefun '.m'],'wt');
+odefun_filepath = [odefun_subdir,'/',odefun_file];
+fid=fopen([odefun_filepath '.m'],'wt');
 
 if ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
   fprintf(fid,'function [Y,T] = %s\n',odefun_file);
   fprintf(fid,'tspan=[%g %g]; dt=%g;\n',tspan,dt);
 else % use codegen
   fprintf(fid,'function [Y,T] = odefun\n'); % this is useful to avoid codegen to be called if the mex file is already created
-  % setting initial conditions as varsize for codegen
-  labels = spec.variables.labels;
-  [ulabels,I] = unique(labels,'stable');
-  for k = 1:length(ulabels)
-    fprintf(fid,'coder.varsize(''%s.%s'');\n',coderprefix,['IC_' ulabels{k}]);
-  end
-  % load params.mat at start of odefun file
-  fprintf(fid,'pset=load(''params.mat'');\n'); % variable name 'pset' must match coderprefix
-  fprintf(fid,'tspan=%s.timelimits;\ndt=%s.dt;\n',coderprefix,coderprefix);
 end
+
+labels = spec.variables.labels;
+[ulabels,I] = unique(labels,'stable');
+for k = 1:length(ulabels)
+  fprintf(fid,'coder.varsize(''%s.%s'');\n',coderprefix,['IC_' ulabels{k}]);
+end
+% load params.mat at start of odefun file
+fprintf(fid,'pset=load(''params.mat'');\n'); % variable name 'pset' must match coderprefix
+fprintf(fid,'tspan=%s.timelimits;\ndt=%s.dt;\n',coderprefix,coderprefix);
 fprintf(fid,'T=tspan(1):dt:tspan(2);\nnstep=length(T);\n');
 
 if ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
   fprintf(fid,'nreports = 5; tmp = 1:(nstep-1)/nreports:nstep; enableLog = tmp(2:end);\n');
 end
-if parms.debug % this is kept only for debugging purposes, as otherwise a new mex file needs to be regenerated each time
-  fprintf(fid,'fprintf(''\\nThe odefun file used is: %s \\n'');\n',odefun_file);
-end
+% if parms.debug % commented as otherwise a new mex file is regenerated for each simulation
+%   fprintf(fid,'fprintf(''\\nThe odefun file used is: %s \\n'');\n',odefun_file);
+% end
 fprintf(fid,'fprintf(''\\nSimulation interval: %%g-%%g\\n'',tspan(1),tspan(2));\n');
 fprintf(fid,'fprintf(''Starting integration (%s, dt=%%g)\\n'',dt);\n',solver);
 
@@ -102,12 +109,6 @@ for k = 1:size(auxvars,1)
   end
   fprintf(fid,'%s = %s;\n',auxvars{k,1},auxvars{k,2});
 end
-%  % evaluate anonymous functions
-%  if ~exist('codegen') || parms.coder == 0 % if matlab coder is not available or you don't want to use it because it does not support your code
-%    for k = 1:size(functions,1)
-%      fprintf(fid,'%s = %s;\n',functions{k,1},functions{k,2});
-%    end
-%  end
 
 % REPLACE X(#:#) with unique variable names X#
 % Set Initial conditions
@@ -123,26 +124,14 @@ for k = 1:length(ulabels)
   varinds = find(strcmp(ulabels{k},labels));
   n = length(varinds); % # cells in the pop with this var   % Npops(ids(varinds(1))==PopID);
   ns(k)=n;
-  if ~exist('codegen') || parms.coder==0
-    fprintf(fid,'%s = zeros(%g,nstep);\n',ulabels{k},n);
-  else
-    fprintf(fid,'%s = zeros(length(%s.%s),nstep);\n',ulabels{k},coderprefix,['IC_' ulabels{k}]);
-  end
+  fprintf(fid,'%s = zeros(length(%s.%s),nstep);\n',ulabels{k},coderprefix,['IC_' ulabels{k}]);
   old = sprintf('X(%g:%g)',cnt,cnt+n-1);
   if n>1
     new = sprintf('%s(:,k-1)',ulabels{k});
-    if ~exist('codegen') || parms.coder==0
-      fprintf(fid,'%s(:,1) = [%s];\n',ulabels{k},num2str(IC(varinds)'));
-    else
-      fprintf(fid,'%s(:,1) = %s.%s;\n',ulabels{k},coderprefix,['IC_' ulabels{k}]);
-    end
+    fprintf(fid,'%s(:,1) = %s.%s;\n',ulabels{k},coderprefix,['IC_' ulabels{k}]);
   else
     new = sprintf('%s(k-1)',ulabels{k});
-    if ~exist('codegen') || parms.coder==0
-      fprintf(fid,'%s(1) = [%s];\n',ulabels{k},num2str(IC(varinds)'));
-    else
-      fprintf(fid,'%s(1) = %s.%s;\n',ulabels{k},coderprefix,['IC_' ulabels{k}]);
-    end
+    fprintf(fid,'%s(1) = %s.%s;\n',ulabels{k},coderprefix,['IC_' ulabels{k}]);
   end
   model = strrep(model,old,new);
   cnt = cnt + n;
@@ -267,11 +256,9 @@ fprintf(fid,')'';\n');
 fclose(fid);
 
 % wait for file before continuing to simulation
-while ~exist([odefun '.m'],'file')
+while ~exist([odefun_filepath '.m'],'file')
   pause(.01);
 end
-%fprintf('model written to: %s.m\n',odefun);
-%{
+
 fprintf('running simulation...\n');
-eval(sprintf('[data,t]=%s;',odefun));
-%}
+% eval(sprintf('[data,t]=%s;',odefun_file));

--- a/matlab/functions/dnsimulator.m
+++ b/matlab/functions/dnsimulator.m
@@ -67,9 +67,10 @@ save(fullfile(odefun_subdir,'params.mat'),'p');
 
 % create odefun file that integrates the ODE system
 odefun_file = [odefun_dir,'_' datestr(now,'yyyymmdd_HHMMSS_FFF')];
-if parms.cluster_flag % not assuming the cluster is always used
-  odefun_file = [odefun_file '_' spec.jobnumber]
-end
+% this doesn't work for me and I don't think it is actually needed
+%  if parms.cluster_flag % not assuming the cluster is always used
+%    odefun_file = [odefun_file '_' spec.jobnumber]
+%  end
 odefun_filepath = [odefun_subdir,'/',odefun_file];
 fid=fopen([odefun_filepath '.m'],'wt');
 

--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -158,6 +158,10 @@ switch parms.SOLVER
       end
       cd(cwd);
     catch err
+      fprintf('\n\n%s\n\n',err.message);
+      for i=1:length(err.stack)
+        fprintf('\t in %s (line %g)\n',err.stack(i).name,err.stack(i).line);
+      end
       simdata=[];
       if parms.debug==0
         rmdir(odefun_subdir,'s');

--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -127,13 +127,15 @@ switch parms.SOLVER
         while ~isempty(res_diff) && j <= length(dirinfo)
           if ~dirinfo(j).isdir && ~strcmp(dirinfo(j).name(1:end-2),odefun_filename) && strncmp(dirinfo(j).name,odefun_filename,6) &&  strncmp(dirinfo(j).name(end-1:end),'.m',2)
             [~,res_diff] = system(['diff ',odefun_filename,'.m ',dirinfo(j).name]);
-            if isempty(res_diff)
+            if isempty(res_diff) && exist([dirinfo(j).name(1:end-2),'_mex.mexa64'],'file')
               delete([odefun_filename,'.m']);
               odefun_filename = dirinfo(j).name(1:end-2);
               filemex = [odefun_filename,'_mex'];
               fprintf('\n\nUsing previous mex file: %s\n\n',filemex);
               copyfile([filemex,'.mexa64'],[odefun_subdir,'/']);
               cd(odefun_subdir);
+            elseif isempty(res_diff)
+              delete([dirinfo(j).name(1:end-2),'.m']);
             end
           end
           j = j+1;

--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -118,7 +118,7 @@ switch parms.SOLVER
         [data,t] = feval(odefun_filename);
       else
         odefun_dir = fullfile('/',tmp_str{1:end-2});
-        copyfile([odefun_filepath,'.m'],odefun_dir)
+        copyfile([odefun_filepath,'.m'],[odefun_dir,'/'])
         cd(odefun_dir);
         odefun_mfiles = {};
         dirinfo = dir('.');
@@ -132,7 +132,7 @@ switch parms.SOLVER
               odefun_filename = dirinfo(j).name(1:end-2);
               filemex = [odefun_filename,'_mex'];
               fprintf('\n\nUsing previous mex file: %s\n\n',filemex);
-              copyfile([filemex,'.mexa64'],odefun_subdir);
+              copyfile([filemex,'.mexa64'],[odefun_subdir,'/']);
               cd(odefun_subdir);
             end
           end
@@ -145,7 +145,7 @@ switch parms.SOLVER
           codegen_odefun(odefun_filename);
           toc
           filemex = [odefun_filename,'_mex'];
-          copyfile([filemex,'.mexa64'],odefun_dir);
+          copyfile([filemex,'.mexa64'],[odefun_dir,'/']);
         end
         tic
         [data,t] = feval(filemex);

--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -158,16 +158,12 @@ switch parms.SOLVER
       end
       cd(cwd);
     catch err
-      fprintf('Error: %s\n',err.message);
-      for i=1:length(err.stack)
-        fprintf('\t in %s (line %g)\n',err.stack(i).name,err.stack(i).line);
-      end
       simdata=[];
       if parms.debug==0
         rmdir(odefun_subdir,'s');
       end
       cd(cwd);
-      return
+      rethrow(err);
     end
   otherwise
     [data,t] = biosimulator(model,ic,functions,auxvars,args{:});

--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -139,6 +139,7 @@ switch parms.SOLVER
           j = j+1;
         end
         if ~exist('filemex')
+          fprintf('\nNew model detected: generating the mex file...\n');
           cd(odefun_subdir);
           tic
           codegen_odefun(odefun_filename);

--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -131,7 +131,7 @@ switch parms.SOLVER
               delete([odefun_filename,'.m']);
               odefun_filename = dirinfo(j).name(1:end-2);
               filemex = [odefun_filename,'_mex'];
-              display('Using previous mex file');
+              fprintf('\n\nUsing previous mex file: %s\n\n',filemex);
               copyfile([filemex,'.mexa64'],odefun_subdir);
               cd(odefun_subdir);
             end

--- a/matlab/functions/runsim.m
+++ b/matlab/functions/runsim.m
@@ -153,7 +153,7 @@ switch parms.SOLVER
         [data,t] = feval(filemex);
         toc
       end
-      if parms.debug==0
+      if parms.debug==0 && parms.cluster_flag == 0
         rmdir(odefun_subdir,'s');
       end
       cd(cwd);
@@ -163,7 +163,7 @@ switch parms.SOLVER
         fprintf('\t in %s (line %g)\n',err.stack(i).name,err.stack(i).line);
       end
       simdata=[];
-      if parms.debug==0
+      if parms.debug==0 && parms.cluster_flag == 0
         rmdir(odefun_subdir,'s');
       end
       cd(cwd);


### PR DESCRIPTION
Added several changes that improve usability: 1) params.mat is used whether or not the coder is available or enabled; 2) odefun m (and mex) files together with params.mat are located in different subfolders, specifically for each simulation, so different mat files do not interfere with each other when running more than one simulation at a time; 3) added the possibility to identify those subfolders with an identifier argument; 4) these subfolders will be automatically deleted if debug is set to 0, but kept otherwise to ease debugging; 5) if the identifier is not used, the 'default' identifier is used, and if debug is set to 1, default identifiers are incremental (default, default_1, default_2...) so they (again) do not interfere.

IMPORTANT:

Note 1: I tested the code with runsim locally for all combinations of coder, debug and identifier.
Note 2: Needs testing in the cluster (partially tested in the cluster, few commits fixed minor remaining issues).
Note 3: I do not use simstudy so it will likely require some minor tweaks (see runsim for a reference).
